### PR TITLE
Fixed issue where non-visible files appear in menu

### DIFF
--- a/bin/islet_shell
+++ b/bin/islet_shell
@@ -310,6 +310,7 @@ config_menu(){
 
   # Iterate over configuration files in $CONFIG_DIR and display them as options
   # It prints the config file ($config) and its description ($DESCRIPTION)
+  unset BANNER VISIBLE ENABLE PLUGIN config config_name
   for config in environments/*.conf plugins/*.conf; do
     [[ -f "$config" ]] && . "$config"
     if [[ "$VISIBLE" = "yes" || "$ENABLE" = "yes" ]]; then


### PR DESCRIPTION
When the first conf file alphabetically didn't have VISIBLE set to "yes", then it would be shown after a plugin was called.